### PR TITLE
Add mounts and post-create command to devcontainer configuration DELTA-39

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,12 @@
         // Path is relative to the devcontainer.json file.
         "dockerfile": "Dockerfile"
     },
+    "mounts": [
+        // Use named volumes for node_modules to improve performance
+        "source=matbay-backend-node-modules,target=${containerWorkspaceFolder}/backend/node_modules,type=volume",
+        "source=matbay-frontend-node-modules,target=${containerWorkspaceFolder}/frontend/node_modules,type=volume"
+    ],
+    "postCreateCommand": "cd backend && bun install && cd ../frontend && bun install",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
# Description
<!-- Keep only relevant sections -->

## :hammer_and_wrench: Internal

- Added named volume mounts for `backend/node_modules` and `frontend/node_modules` in `.devcontainer/devcontainer.json` to improve performance.
- Added a `postCreateCommand` to automatically install dependencies in both `backend` and `frontend` after container creation.