### PR TITLE
Group Angular packages update and switch to monthly updates 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,8 @@ updates:
       - "/frontend"
       - "/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      angular:
+        patterns:
+          - "@angular*" 


### PR DESCRIPTION
# Description
<!-- Keep only relevant sections -->
Update the Dependabot configuration to better control the number of open pull requests.

## :hammer_and_wrench: Internal
* Change the interval between Dependabot updates from `weekly` to `monthly`.
* Regroup all the `@angular*` packages in one Dependabot's PR.