### PR TITLE
Refactor environment configuration and update HTTP/WebSocket URLs

### DIFF
--- a/frontend/src/app/services/delta-auth.ts
+++ b/frontend/src/app/services/delta-auth.ts
@@ -12,6 +12,7 @@ export class DeltaAuth {
   private uid$: ReplaySubject<string> = new ReplaySubject<string>(1);
   private isAuthenticated$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
+  // Service injections
   private auth = inject(AuthService);
   private document = inject(DOCUMENT);
   private http = inject(HttpClient);
@@ -23,7 +24,8 @@ export class DeltaAuth {
   }
 
   onConnect(claims: IdToken): void {
-    this.http.get(`${environment.server.url}/api/auth/login`, {
+    const serverURL = `${environment.server.httpProtocol}${environment.server.domain}`;
+    this.http.get(`${serverURL}/api/auth/login`, {
       headers: {
         "delta-auth": claims.__raw
       },

--- a/frontend/src/app/services/http-requests.ts
+++ b/frontend/src/app/services/http-requests.ts
@@ -8,13 +8,16 @@ import { lastValueFrom } from 'rxjs';
   providedIn: 'root'
 })
 export class HttpRequests {
+  // Service injections
   private deltaAuth = inject(DeltaAuth);
   private http = inject(HttpClient)
+
+  private readonly url = `${environment.server.httpProtocol}${environment.server.domain}`
 
   async authenticatedGetRequest(endpoint: string): Promise<string> {
     const token = await this.deltaAuth.getIdToken();
 
-    return lastValueFrom(this.http.get(`${environment.server.url}/api/${endpoint}`, {
+    return lastValueFrom(this.http.get(`${this.url}/api/${endpoint}`, {
       headers: {
         "delta-auth": token.__raw
       },
@@ -25,7 +28,7 @@ export class HttpRequests {
   async authenticatedPostRequest(endpoint: string, body: unknown): Promise<string> {
     const token = await this.deltaAuth.getIdToken();
 
-    return lastValueFrom(this.http.post(`${environment.server.url}/api/${endpoint}`, body, {
+    return lastValueFrom(this.http.post(`${this.url}/api/${endpoint}`, body, {
       headers: {
         "delta-auth": token.__raw
       },

--- a/frontend/src/app/services/ws-requests.ts
+++ b/frontend/src/app/services/ws-requests.ts
@@ -12,7 +12,7 @@ export type CallbackFunction = (...args: any[]) => void;
 })
 export class WsRequests {
   private deltaAuth = inject(DeltaAuth);
-  private socket = io(environment.server.ws);
+  private socket = io(`${environment.server.wsProtocol}${environment.server.domain}`);
 
   on(event: WebsocketEvents, callback: CallbackFunction) {
     this.socket.on(event, callback);

--- a/frontend/src/environments/environment.template.ts
+++ b/frontend/src/environments/environment.template.ts
@@ -15,7 +15,8 @@ export const environment = {
 
   // Variables necessary for proper communication with the backend.
   server: {
-    url: "YOUR_SERVER_URL",           // The URL where your instance of the backend is hosted and joinable.
-    ws: "YOUR_WS_URL"
+    domain: "YOUR_SERVER_DOMAIN",         // Domain name of your backend instance
+    httpProtocol: "YOUR_HTTP_PROTOCOL",   // HTTP protocol (should be "http://" or "https://")
+    wsProtocol: "YOUR_WS_PROTOCOL"        // Websocket protocol (should be "ws://" or "wss://")
   }
 }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -5,7 +5,8 @@ export const environment = {
     client: import.meta.env["NG_APP_AUTH0_CLIENT"],
   },
   server: {
-    url: import.meta.env["NG_APP_SERVER_URL"],
-    ws: import.meta.env["NG_APP_WS_URL"]
+    domain: import.meta.env["NG_APP_SERVER_DOMAIN"],
+    httpProtocol: import.meta.env["NG_APP_SERVER_HTTP_PROTOCOL"],
+    wsProtocol: import.meta.env["NG_APP_SERVER_WS_PROTOCOL"]
   }
 };


### PR DESCRIPTION
# Description
<!-- Keep only relevant sections -->

## :hammer_and_wrench: Internal
* Splited the env variables `NG_APP_URL` and `NG_APP_WS` into `NG_APP_SERVER_DOMAIN`, `NG_APP_HTTP_PROTOCOL` and `NG_APP_WS_PROTOCOL`