### PR TITLE
Increase maximum size limits for component styles in angular.json (hotfix)

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -50,8 +50,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "12kB",
+                  "maximumError": "16kB"
                 }
               ],
               "outputHashing": "all",


### PR DESCRIPTION
# Description
<!-- Keep only relevant sections -->


## :hammer_and_wrench: Internal
* Increase maximum size limits for component styles in angular.json