### PR TITLE
Switch frontend profile URLs from UIDs to handles (DELTA-125)

### DIFF
--- a/backend/biome.json
+++ b/backend/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
     "vcs": {
         "enabled": false,
         "clientKind": "git",

--- a/backend/biome.json
+++ b/backend/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
     "vcs": {
         "enabled": false,
         "clientKind": "git",

--- a/backend/drizzle/0014_cold_thundra.sql
+++ b/backend/drizzle/0014_cold_thundra.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `users` RENAME COLUMN "username" TO "handle";--> statement-breakpoint
+DROP INDEX `username_idx`;--> statement-breakpoint
+CREATE UNIQUE INDEX `handle_idx` ON `users` (`handle`);

--- a/backend/drizzle/meta/0014_snapshot.json
+++ b/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,732 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "78d3e97a-e6bd-4a15-832f-5b04f4e06a19",
+  "prevId": "65bf4956-4e28-45b9-86fc-c7db91c961f6",
+  "tables": {
+    "albums": {
+      "name": "albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creationDate": {
+          "name": "creationDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artists": {
+      "name": "artists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creationDate": {
+          "name": "creationDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "artistAlbum": {
+      "name": "artistAlbum",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album": {
+          "name": "album",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "artistAlbum_artist_album_unique": {
+          "name": "artistAlbum_artist_album_unique",
+          "columns": [
+            "artist",
+            "album"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "artistAlbum_artist_artists_id_fk": {
+          "name": "artistAlbum_artist_artists_id_fk",
+          "tableFrom": "artistAlbum",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artistAlbum_album_albums_id_fk": {
+          "name": "artistAlbum_album_albums_id_fk",
+          "tableFrom": "artistAlbum",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "constitutions": {
+      "name": "constitutions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creationDate": {
+          "name": "creationDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nSongs": {
+          "name": "nSongs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "constitutions_owner_users_id_fk": {
+          "name": "constitutions_owner_users_id_fk",
+          "tableFrom": "constitutions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "songs": {
+      "name": "songs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creationDate": {
+          "name": "creationDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "primaryArtist": {
+          "name": "primaryArtist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "songs_title_primaryArtist_unique": {
+          "name": "songs_title_primaryArtist_unique",
+          "columns": [
+            "title",
+            "primaryArtist"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "songs_primaryArtist_artists_id_fk": {
+          "name": "songs_primaryArtist_artists_id_fk",
+          "tableFrom": "songs",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "primaryArtist"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "songAlbum": {
+      "name": "songAlbum",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "song": {
+          "name": "song",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album": {
+          "name": "album",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "songAlbum_song_album_unique": {
+          "name": "songAlbum_song_album_unique",
+          "columns": [
+            "song",
+            "album"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "songAlbum_song_songs_id_fk": {
+          "name": "songAlbum_song_songs_id_fk",
+          "tableFrom": "songAlbum",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "song"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "songAlbum_album_albums_id_fk": {
+          "name": "songAlbum_album_albums_id_fk",
+          "tableFrom": "songAlbum",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "songArtist": {
+      "name": "songArtist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "song": {
+          "name": "song",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contribution": {
+          "name": "contribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'main'"
+        }
+      },
+      "indexes": {
+        "songArtist_artist_song_contribution_unique": {
+          "name": "songArtist_artist_song_contribution_unique",
+          "columns": [
+            "artist",
+            "song",
+            "contribution"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "songArtist_song_songs_id_fk": {
+          "name": "songArtist_song_songs_id_fk",
+          "tableFrom": "songArtist",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "song"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "songArtist_artist_artists_id_fk": {
+          "name": "songArtist_artist_artists_id_fk",
+          "tableFrom": "songArtist",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "songConstitution": {
+      "name": "songConstitution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "song": {
+          "name": "song",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "constitution": {
+          "name": "constitution",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addDate": {
+          "name": "addDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "songConstitution_song_user_constitution_unique": {
+          "name": "songConstitution_song_user_constitution_unique",
+          "columns": [
+            "song",
+            "user",
+            "constitution"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "songConstitution_song_songs_id_fk": {
+          "name": "songConstitution_song_songs_id_fk",
+          "tableFrom": "songConstitution",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "song"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "songConstitution_user_users_id_fk": {
+          "name": "songConstitution_user_users_id_fk",
+          "tableFrom": "songConstitution",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "songConstitution_constitution_constitutions_id_fk": {
+          "name": "songConstitution_constitution_constitutions_id_fk",
+          "tableFrom": "songConstitution",
+          "tableTo": "constitutions",
+          "columnsFrom": [
+            "constitution"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "songSource": {
+      "name": "songSource",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creationDate": {
+          "name": "creationDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "song": {
+          "name": "song",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sourceID": {
+          "name": "sourceID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "songSource_song_sourceID_platform_unique": {
+          "name": "songSource_song_sourceID_platform_unique",
+          "columns": [
+            "song",
+            "sourceID",
+            "platform"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "songSource_song_songs_id_fk": {
+          "name": "songSource_song_songs_id_fk",
+          "tableFrom": "songSource",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "song"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authID": {
+          "name": "authID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageURL": {
+          "name": "imageURL",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joinDate": {
+          "name": "joinDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authID_idx": {
+          "name": "authID_idx",
+          "columns": [
+            "authID"
+          ],
+          "isUnique": true
+        },
+        "handle_idx": {
+          "name": "handle_idx",
+          "columns": [
+            "handle"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "userConstitution": {
+      "name": "userConstitution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "constitution": {
+          "name": "constitution",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joinDate": {
+          "name": "joinDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userConstitution_user_constitution_unique": {
+          "name": "userConstitution_user_constitution_unique",
+          "columns": [
+            "user",
+            "constitution"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "userConstitution_user_users_id_fk": {
+          "name": "userConstitution_user_users_id_fk",
+          "tableFrom": "userConstitution",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "userConstitution_constitution_constitutions_id_fk": {
+          "name": "userConstitution_constitution_constitutions_id_fk",
+          "tableFrom": "userConstitution",
+          "tableTo": "constitutions",
+          "columnsFrom": [
+            "constitution"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {
+      "\"users\".\"username\"": "\"users\".\"handle\""
+    }
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1767041612572,
       "tag": "0013_first_ultimo",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1777156323054,
+      "tag": "0014_cold_thundra",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/auth/http.ts
+++ b/backend/src/auth/http.ts
@@ -74,7 +74,7 @@ async function login(req: Request, res: Response) {
         id: "",
         authID,
         displayName: tokenPayload["nickname"] ?? "New User",
-        username: tokenPayload["name"] ?? authID,
+        handle: tokenPayload["name"] ?? authID,
         description: "",
         imageURL: tokenPayload["picture"] ?? "",
         joinDate: new Date().toISOString(),

--- a/backend/src/db/schemas/user.ts
+++ b/backend/src/db/schemas/user.ts
@@ -7,7 +7,7 @@ const users = sqliteTable(
     {
         id: text().primaryKey(),
         authID: text().notNull(),
-        username: text().notNull(),
+        handle: text().notNull(),
         displayName: text().notNull(),
         imageURL: text().notNull(),
         joinDate: text()
@@ -15,7 +15,7 @@ const users = sqliteTable(
             .$defaultFn(() => new Date().toISOString()),
         description: text().notNull(),
     },
-    (table) => [uniqueIndex("authID_idx").on(table.authID), uniqueIndex("username_idx").on(table.username)],
+    (table) => [uniqueIndex("authID_idx").on(table.authID), uniqueIndex("handle_idx").on(table.handle)],
 );
 
 const usersRelations = relations(users, ({ many }) => ({

--- a/backend/src/user/http.ts
+++ b/backend/src/user/http.ts
@@ -1,13 +1,13 @@
 import { eq } from "drizzle-orm";
 import { type Request, type Response, Router } from "express";
 import { Option } from "oxide.ts";
-import type { UserUpdateRequestBody } from "../../../common/user";
+import type { UserIdResponse, UserUpdateRequestBody } from "../../../common/user";
 import { ensureAuthMiddleware } from "../auth/http";
 import { db } from "../db/http";
 import { users } from "../db/schemas";
 import type { DB } from "../db-namepsace";
 import { getBody, getParam, getReqUID, HttpError, HttpStatus, sendResult } from "../utils";
-import { getUser } from "./utils";
+import { getUidFromHandle, getUser } from "./utils";
 
 async function get(req: Request, res: Response): Promise<void> {
     const uid = getParam(req, "uid");
@@ -16,6 +16,19 @@ async function get(req: Request, res: Response): Promise<void> {
         (err) => new HttpError(HttpStatus.NotFound, `failed to get user info from uid ${err}`),
     );
     sendResult(user, res);
+}
+
+async function uidFromHandle(req: Request, res: Response): Promise<void> {
+    const handle = getParam(req, "handle");
+
+    const uid = (await getUidFromHandle(handle))
+        .map(
+            (uid): UserIdResponse => ({
+                id: uid,
+            }),
+        )
+        .mapErr((err) => new HttpError(HttpStatus.NotFound, `failed to get user info from handle ${err}`));
+    sendResult(uid, res);
 }
 
 async function update(req: Request, res: Response): Promise<void> {
@@ -34,6 +47,7 @@ async function update(req: Request, res: Response): Promise<void> {
 const userApiRouter = Router();
 
 userApiRouter.get("/get/:uid", ensureAuthMiddleware, get);
+userApiRouter.get("/uid-from-handle/:handle", ensureAuthMiddleware, uidFromHandle);
 userApiRouter.post("/update", ensureAuthMiddleware, update);
 
 export { userApiRouter };

--- a/backend/src/user/utils.ts
+++ b/backend/src/user/utils.ts
@@ -31,4 +31,15 @@ async function getUserFromAuth(authID: string): Promise<Result<DB.Select.User, E
     return Option(queryResult.unwrap().at(0)).okOr(new Error(`No user with authID: ${authID}`));
 }
 
-export { createUser, getUser, getUserFromAuth };
+async function getUidFromHandle(handle: string): Promise<Result<string, Error>> {
+    const operation = async () => await db.select({ id: users.id }).from(users).where(eq(users.handle, handle));
+
+    const queryResult = await Result.safe(operation());
+    if (queryResult.isErr()) return queryResult;
+
+    return Option(queryResult.unwrap().at(0))
+        .okOr(new Error(`No user with handle: ${handle}`))
+        .map((user) => user.id);
+}
+
+export { createUser, getUidFromHandle, getUser, getUserFromAuth };

--- a/common/user.ts
+++ b/common/user.ts
@@ -1,7 +1,7 @@
 interface User {
   id: string,
   authID: string,
-  username: string,
+  handle: string,
   displayName: string,
   imageURL: string,
   joinDate: string,

--- a/common/user.ts
+++ b/common/user.ts
@@ -8,10 +8,14 @@ interface User {
   description: string,
 }
 
+interface UserIdResponse {
+    id: string
+}
+
 interface UserUpdateRequestBody {
   displayName: string,
   imageURL: string,
   description: string,
 }
 
-export type { User, UserUpdateRequestBody };
+export type { User, UserIdResponse, UserUpdateRequestBody };

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -18,7 +18,7 @@ export const routes: Routes = [
     component: CurrentConstitutionsPage,
   },
   {
-    path: 'users/:id',
+    path: 'users/:handle',
     component: UserPage,
   },
 ];

--- a/frontend/src/app/components/pages/user-page/user-page.html
+++ b/frontend/src/app/components/pages/user-page/user-page.html
@@ -1,7 +1,7 @@
 @if (userError) {
   <p>Error loading user : "{{ userError.error }}".</p>
 } @else if (user) {
-  <h2>{{ user.displayName }} (@{{ user.username }})</h2>
+  <h2>{{ user.displayName }} (@{{ user.handle }})</h2>
   <img [src]="user.imageURL" width="250" height="250" alt="Profile picture of {{ user.displayName }}" />
   <p>Description: {{ user.description }}</p>
   <p>Joined on: {{ user.joinDate }}</p>

--- a/frontend/src/app/components/pages/user-page/user-page.ts
+++ b/frontend/src/app/components/pages/user-page/user-page.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, inject } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { CurrentUserForm } from './current-user-form/current-user-form';
-import { DeltaAuth } from '../../../services/delta-auth';
 import { HttpErrorResponse } from '@angular/common/http';
 import { User } from '../../../../../../common/user';
 import { Users } from '../../../services/users';
@@ -16,7 +15,6 @@ import { Users } from '../../../services/users';
 export class UserPage implements OnDestroy {
   // Service injections
   private activatedRoute = inject(ActivatedRoute);
-  private deltaAuth = inject(DeltaAuth);
   users = inject(Users);
 
   private subscriptions: Subscription = new Subscription();
@@ -36,22 +34,26 @@ export class UserPage implements OnDestroy {
     // Get the user from the route
     this.activatedRoute.params.subscribe((params) => {
       this.userHandle = params['handle'];
-      this.userObs = this.users.get(this.userHandle);
+      this.users.getFromHandle(this.userHandle).then((obs) => {
+        this.userObs = obs;
 
-      const subscription = this.userObs.subscribe({
-        next: (data) => {
-          this.user = data;
-        },
-        error: (err) => {
-          this.userError = err;
-        },
+        const subscription = this.userObs.subscribe({
+          next: (data) => {
+            this.user = data;
+          },
+          error: (err) => {
+            this.userError = err;
+          },
+        });
+
+        this.subscriptions.add(subscription);
       });
 
-      this.deltaAuth.getUid().then((uid) => {
-        this.isCurrentUser = uid === this.userId;
+      this.users.getCurrentUser().then((currentUser) => {
+        currentUser.subscribe((user) => {
+          this.isCurrentUser = user.handle === this.userHandle;
+        })
       });
-
-      this.subscriptions.add(subscription);
     });
   }
 }

--- a/frontend/src/app/components/pages/user-page/user-page.ts
+++ b/frontend/src/app/components/pages/user-page/user-page.ts
@@ -23,7 +23,7 @@ export class UserPage implements OnDestroy {
 
   // Observable of the user data
   private userObs: Observable<User> | undefined;
-  private userId = '';
+  private userHandle = '';
   user: User | undefined;
   userError: HttpErrorResponse | undefined;
   isCurrentUser = false;
@@ -35,8 +35,8 @@ export class UserPage implements OnDestroy {
   constructor() {
     // Get the user from the route
     this.activatedRoute.params.subscribe((params) => {
-      this.userId = params['id'];
-      this.userObs = this.users.get(this.userId);
+      this.userHandle = params['handle'];
+      this.userObs = this.users.get(this.userHandle);
 
       const subscription = this.userObs.subscribe({
         next: (data) => {

--- a/frontend/src/app/components/pages/user-page/user-page.ts
+++ b/frontend/src/app/components/pages/user-page/user-page.ts
@@ -52,7 +52,7 @@ export class UserPage implements OnDestroy {
       this.users.getCurrentUser().then((currentUser) => {
         currentUser.subscribe((user) => {
           this.isCurrentUser = user.handle === this.userHandle;
-        })
+        });
       });
     });
   }

--- a/frontend/src/app/components/utils/redirect-to-user-profile/redirect-to-user-profile.html
+++ b/frontend/src/app/components/utils/redirect-to-user-profile/redirect-to-user-profile.html
@@ -1,5 +1,5 @@
 @if (user(); as user) {
-  <span (click)="redirectToUserPage(user.id)" (keydown.enter)="redirectToUserPage(user.id)" tabindex="0">
+  <span (click)="redirectToUserPage(user.handle)" (keydown.enter)="redirectToUserPage(user.handle)" tabindex="0">
     @if (showName()) {
       {{ user.displayName }}
     }

--- a/frontend/src/app/components/utils/redirect-to-user-profile/redirect-to-user-profile.ts
+++ b/frontend/src/app/components/utils/redirect-to-user-profile/redirect-to-user-profile.ts
@@ -16,7 +16,7 @@ export class RedirectToUserProfile {
 
   private router = inject(Router);
 
-  redirectToUserPage(id: string): void {
-    this.router.navigate(['/users', id]);
+  redirectToUserPage(handle: string): void {
+    this.router.navigate(['/users', handle]);
   }
 }

--- a/frontend/src/app/navigation-bar/navigation-bar.ts
+++ b/frontend/src/app/navigation-bar/navigation-bar.ts
@@ -32,8 +32,6 @@ export class NavigationBar implements OnInit {
   }
 
   redirectToProfile(): void {
-    this.deltaAuth.getUid().then((uid) => {
-      this.router.navigate(['/users', uid]);
-    });
+    this.router.navigate(['/users', this.user?.handle]);
   }
 }

--- a/frontend/src/app/navigation-bar/navigation-bar.ts
+++ b/frontend/src/app/navigation-bar/navigation-bar.ts
@@ -16,7 +16,7 @@ export class NavigationBar implements OnInit {
   deltaAuth = inject(DeltaAuth);
   users = inject(Users);
   private readonly router = inject(Router);
-  user: User | null | undefined = null;
+  user: User | undefined;
 
   ngOnInit(): void {
     this.deltaAuth.getUid().then((uid) => {

--- a/frontend/src/app/services/users.ts
+++ b/frontend/src/app/services/users.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable, ReplaySubject } from 'rxjs';
-import { User, UserUpdateRequestBody } from '../../../../common/user';
+import { User, UserIdResponse, UserUpdateRequestBody } from '../../../../common/user';
 import { DeltaAuth } from './delta-auth';
 import { HttpRequests } from './requests/http-requests';
 
@@ -36,7 +36,12 @@ export class Users {
     return newUser.asObservable();
   }
 
-  async getCurrentUser(): Promise<Observable<User> | undefined> {
+  async getFromHandle(handle: string): Promise<Observable<User>> {
+    const response = await this.httpRequests.authenticatedGetRequest<UserIdResponse>(`user/uid-from-handle/${handle}`);
+    return this.get(response.id);
+  }
+
+  async getCurrentUser(): Promise<Observable<User>> {
     const uid = await this.deltaAuth.getUid();
     return this.get(uid);
   }

--- a/frontend/src/app/services/users.ts
+++ b/frontend/src/app/services/users.ts
@@ -15,6 +15,10 @@ export class Users {
   // Cache of user data to avoid redundant requests
   private users = new Map<string, ReplaySubject<User>>();
 
+  // Indices
+  /// handle => uid
+  private handleIndex = new Map<string, string>();
+
   get(uid: string): Observable<User> {
     // Check if we already have the requested user
     const user = this.users.get(uid);
@@ -27,6 +31,7 @@ export class Users {
     this.httpRequests
       .authenticatedGetRequest<User>(`user/get/${uid}`)
       .then((user) => {
+        this.handleIndex.set(user.handle, user.id);
         newUser.next(user);
       })
       .catch((error) => {
@@ -37,8 +42,12 @@ export class Users {
   }
 
   async getFromHandle(handle: string): Promise<Observable<User>> {
-    const response = await this.httpRequests.authenticatedGetRequest<UserIdResponse>(`user/uid-from-handle/${handle}`);
-    return this.get(response.id);
+    let uid = this.handleIndex.get(handle);
+    if (!uid) {
+      uid = (await this.httpRequests.authenticatedGetRequest<UserIdResponse>(`user/uid-from-handle/${handle}`)).id;
+    }
+
+    return this.get(uid);
   }
 
   async getCurrentUser(): Promise<Observable<User>> {


### PR DESCRIPTION
# Description
This PR changes the behavior of the profile route to use human readable handles instead of UIDs

## :hammer_and_wrench: Internal
- renamed and unified `user.username` to `user.handle`
- added an endpoint to map a `user.handle` to `user.id`
- changed `app-redirect-to-user-profile` to use handles
- changed navbar component to use handles for profile redirect