### PR TITLE
Enable deletion of song participations from a constitution (DELTA-92)

### DIFF
--- a/backend/biome.json
+++ b/backend/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
     "vcs": {
         "enabled": false,
         "clientKind": "git",

--- a/backend/src/constitution/http.ts
+++ b/backend/src/constitution/http.ts
@@ -5,6 +5,7 @@ import type {
     CreateConstitutionRequestBody,
     JoinConstitutionRequestBody,
     LeaveConstitutionRequestBody,
+    RemoveSongConstitutionRequestBody,
 } from "../../../common/constitution";
 import { ensureAuthMiddleware } from "../auth/http";
 import { getBody, getParam, getReqUID, HttpError, HttpStatus, sendResult, unwrap } from "../utils";
@@ -16,7 +17,9 @@ import {
     getConstitution,
     getCurrentConstitutionsIDs,
     getDBConstitution,
+    getSongConstitution,
     isMember,
+    removeSongFromConstitution,
     removeUserFromConstitution,
 } from "./utils";
 
@@ -47,10 +50,7 @@ async function addSong(req: Request, res: Response): Promise<void> {
     const isMemberOfCst = unwrap(
         (await isMember(uid, participation.constitution)).mapErr(
             (err) =>
-                new HttpError(
-                    HttpStatus.InternalError,
-                    `failed to verify if user is member of constitution: ${err.message}`,
-                ),
+                new HttpError(HttpStatus.InternalError, `failed to verify if user is member of constitution: ${err}`),
         ),
     );
     if (!isMemberOfCst) {
@@ -72,7 +72,7 @@ async function addSong(req: Request, res: Response): Promise<void> {
             (err) =>
                 new HttpError(
                     HttpStatus.InternalError,
-                    `failed to get constitution '${participation.constitution}' ${err.message}`,
+                    `failed to get constitution '${participation.constitution}': ${err}`,
                 ),
         ),
     );
@@ -81,7 +81,7 @@ async function addSong(req: Request, res: Response): Promise<void> {
             (err) =>
                 new HttpError(
                     HttpStatus.InternalError,
-                    `failed to count songs of user '${uid}' in constitution '${participation.constitution}' ${err.message}`,
+                    `failed to count songs of user '${uid}' in constitution '${participation.constitution}': ${err}`,
                 ),
         ),
     );
@@ -103,11 +103,35 @@ async function addSong(req: Request, res: Response): Promise<void> {
         (err) =>
             new HttpError(
                 HttpStatus.UnprocessableContent,
-                `failed to add song '${participation.song}' constitution '${participation.constitution}' ${err}`,
+                `failed to add song '${participation.song}' constitution '${participation.constitution}': ${err}`,
             ),
     );
 
     sendResult(result, res);
+}
+
+async function removeSong(req: Request, res: Response): Promise<void> {
+    const uid = getReqUID(req);
+    const id = getBody<RemoveSongConstitutionRequestBody>(req).songParticipationId;
+
+    const songParticipationInfo = unwrap(
+        (await getSongConstitution(id)).mapErr(
+            (err) => new HttpError(HttpStatus.NotFound, `no song participation found with id '${id}': ${err}`),
+        ),
+    );
+
+    if (songParticipationInfo.user !== uid) {
+        sendResult(
+            Err(new HttpError(HttpStatus.Unauthorized, `you are not authorized to perform this operation`)),
+            res,
+        );
+        return;
+    }
+
+    const deletionResult = (await removeSongFromConstitution(id)).mapErr(
+        (err) => new HttpError(HttpStatus.InternalError, `failed to delete song participation '${id}': ${err}`),
+    );
+    sendResult(deletionResult, res);
 }
 
 async function create(req: Request, res: Response): Promise<void> {
@@ -152,7 +176,7 @@ async function leave(req: Request, res: Response): Promise<void> {
     );
 
     const result = (await removeUserFromConstitution(uid, id)).mapErr(
-        (err) => new HttpError(HttpStatus.UnprocessableContent, `failed to leave constitution ${err}`),
+        (err) => new HttpError(HttpStatus.UnprocessableContent, `failed to leave constitution: ${err}`),
     );
     sendResult(result, res);
 }
@@ -164,6 +188,7 @@ constitutionApiRouter.get("/get/:id", ensureAuthMiddleware, get);
 
 constitutionApiRouter.post("/addSong", ensureAuthMiddleware, addSong);
 constitutionApiRouter.post("/create", ensureAuthMiddleware, create);
+constitutionApiRouter.post("/removeSong", ensureAuthMiddleware, removeSong);
 constitutionApiRouter.post("/join", ensureAuthMiddleware, join);
 constitutionApiRouter.post("/leave", ensureAuthMiddleware, leave);
 

--- a/backend/src/constitution/utils.ts
+++ b/backend/src/constitution/utils.ts
@@ -6,7 +6,7 @@ import { db } from "../db/http.ts";
 import { constitutions, songConstitution, userConstitution } from "../db/schemas/index.ts";
 import type { DB } from "../db-namepsace.ts";
 import { unwrap } from "../utils.ts";
-import { onSongAddCallback, onUserJoinCallback, onUserLeaveCallback } from "./ws.ts";
+import { onSongAddCallback, onSongRemoveCallback, onUserJoinCallback, onUserLeaveCallback } from "./ws.ts";
 
 async function createConstitution(cstInfos: DB.Insert.Constitution): Promise<Result<DB.Select.Constitution, Error>> {
     return Result.safe(
@@ -79,9 +79,9 @@ async function removeSongFromConstitution(id: number): Promise<Result<Unit, Erro
         .andThen((entries) =>
             Option(entries.at(0)).okOr(new Error("failed to remove song participation from database")),
         )
-        .map((_songParticipation) => {
-            // TODO: callback
-
+        .map((songParticipation) => {
+            // Update users who were listening to changes
+            onSongRemoveCallback(songParticipation);
             return {};
         });
 }

--- a/backend/src/constitution/utils.ts
+++ b/backend/src/constitution/utils.ts
@@ -44,6 +44,14 @@ async function addUserToConstitution(uid: string, cstid: number, tx?: DB.Transac
         });
 }
 
+async function getSongConstitution(id: number): Promise<Result<DB.Select.SongConstitution, Error>> {
+    const operation = async () => await db.select().from(songConstitution).where(eq(songConstitution.id, id));
+
+    return (await Result.safe(operation())).andThen((val) =>
+        Option(val.at(0)).okOr(new Error(`No songConstitution with id '${id}'`)),
+    );
+}
+
 async function addSongToConstitution(constitution: number, song: number, user: string): Promise<Result<Unit, Error>> {
     const operation = async () =>
         await db
@@ -64,6 +72,20 @@ async function addSongToConstitution(constitution: number, song: number, user: s
         });
 }
 
+async function removeSongFromConstitution(id: number): Promise<Result<Unit, Error>> {
+    const operation = async () => await db.delete(songConstitution).where(eq(songConstitution.id, id)).returning();
+
+    return (await Result.safe(operation()))
+        .andThen((entries) =>
+            Option(entries.at(0)).okOr(new Error("failed to remove song participation from database")),
+        )
+        .map((_songParticipation) => {
+            // TODO: callback
+
+            return {};
+        });
+}
+
 async function getConstitution(id: number): Promise<Result<Constitution, Error>> {
     // Get the constitution with :
     // - The list of songs in the constitution
@@ -80,6 +102,7 @@ async function getConstitution(id: number): Promise<Result<Constitution, Error>>
                 },
                 songConstitution: {
                     columns: {
+                        id: true,
                         song: true,
                         user: true,
                         addDate: true,
@@ -89,12 +112,12 @@ async function getConstitution(id: number): Promise<Result<Constitution, Error>>
         });
 
     return (await Result.safe(operation())).andThen((val) =>
-        Option(val.at(0)).okOr(new Error(`No constitution with id: ${id}`)),
+        Option(val.at(0)).okOr(new Error(`No constitution with id '${id}'`)),
     );
 }
 
 async function getCurrentConstitutionsIDs(): Promise<Result<number[], Error>> {
-    // TODO : Should only returns the constitutions that the user should have access. Currently returns all ids.
+    // TODO : Should only return the constitutions that the user should have access to. Currently returns all ids.
     const operation = async () => await db.select({ id: constitutions.id }).from(constitutions);
 
     return (await Result.safe(operation())).map((constitutions) => constitutions.map((cst) => cst.id));
@@ -116,7 +139,7 @@ async function countSongsOfUser(cstid: number, uid: string): Promise<Result<numb
             .where(and(eq(songConstitution.user, uid), eq(songConstitution.constitution, cstid)));
 
     return (await Result.safe(operation()))
-        .andThen((counts) => Option(counts.at(0)).okOr(new Error(`failed to count songs of user ${uid}`)))
+        .andThen((counts) => Option(counts.at(0)).okOr(new Error(`failed to count songs of user '${uid}'`)))
         .map((c) => c.count);
 }
 
@@ -154,6 +177,8 @@ export {
     getConstitution,
     getCurrentConstitutionsIDs,
     getDBConstitution,
+    getSongConstitution,
     isMember,
+    removeSongFromConstitution,
     removeUserFromConstitution,
 };

--- a/backend/src/constitution/ws.ts
+++ b/backend/src/constitution/ws.ts
@@ -2,6 +2,7 @@ import type { Socket } from "socket.io";
 import {
     WebsocketEvents,
     type WSCstSongAddMessage,
+    type WSCstSongRemoveMessage,
     type WSCstSubscribeMessage,
     type WSCstUnsubscribeMessage,
     type WSCstUserJoinMessage,
@@ -24,6 +25,7 @@ function attachWSListeners(socket: Socket): void {
         const isValid = await validateMessage(message);
         if (!isValid) return;
         socket.join(`${WebsocketEvents.CST_SONG_ADD}:${message.constitution}`);
+        socket.join(`${WebsocketEvents.CST_SONG_REMOVE}:${message.constitution}`);
         socket.join(`${WebsocketEvents.CST_USER_JOIN}:${message.constitution}`);
         socket.join(`${WebsocketEvents.CST_USER_LEAVE}:${message.constitution}`);
     });
@@ -33,9 +35,41 @@ function attachWSListeners(socket: Socket): void {
         const isValid = await validateMessage(message);
         if (!isValid) return;
         socket.leave(`${WebsocketEvents.CST_SONG_ADD}:${message.constitution}`);
+        socket.leave(`${WebsocketEvents.CST_SONG_REMOVE}:${message.constitution}`);
         socket.leave(`${WebsocketEvents.CST_USER_JOIN}:${message.constitution}`);
         socket.leave(`${WebsocketEvents.CST_USER_LEAVE}:${message.constitution}`);
     });
+}
+
+function onSongAddCallback(addInfo: DB.Select.SongConstitution): void {
+    const message: WSCstSongAddMessage = {
+        constitution: addInfo.constitution,
+        songConstitution: {
+            id: addInfo.id,
+            song: addInfo.song,
+            user: addInfo.user,
+            addDate: addInfo.addDate,
+        },
+    };
+
+    io.to(`${WebsocketEvents.CST_SONG_ADD}:${addInfo.constitution}`).emit(WebsocketEvents.CST_SONG_ADD, message);
+}
+
+function onSongRemoveCallback(removeInfo: DB.Select.SongConstitution): void {
+    const message: WSCstSongRemoveMessage = {
+        constitution: removeInfo.constitution,
+        songConstitution: {
+            id: removeInfo.id,
+            song: removeInfo.song,
+            user: removeInfo.user,
+            addDate: removeInfo.addDate,
+        },
+    };
+
+    io.to(`${WebsocketEvents.CST_SONG_REMOVE}:${removeInfo.constitution}`).emit(
+        WebsocketEvents.CST_SONG_REMOVE,
+        message,
+    );
 }
 
 function onUserJoinCallback(joinInfo: DB.Select.UserConstitution): void {
@@ -59,17 +93,4 @@ function onUserLeaveCallback(leaveInfo: DB.Select.UserConstitution): void {
     io.to(`${WebsocketEvents.CST_USER_LEAVE}:${leaveInfo.constitution}`).emit(WebsocketEvents.CST_USER_LEAVE, message);
 }
 
-function onSongAddCallback(addInfo: DB.Select.SongConstitution): void {
-    const message: WSCstSongAddMessage = {
-        constitution: addInfo.constitution,
-        songConstitution: {
-            song: addInfo.song,
-            user: addInfo.user,
-            addDate: addInfo.addDate,
-        },
-    };
-
-    io.to(`${WebsocketEvents.CST_SONG_ADD}:${addInfo.constitution}`).emit(WebsocketEvents.CST_SONG_ADD, message);
-}
-
-export { attachWSListeners, onSongAddCallback, onUserJoinCallback, onUserLeaveCallback };
+export { attachWSListeners, onSongAddCallback, onSongRemoveCallback, onUserJoinCallback, onUserLeaveCallback };

--- a/common/constitution.ts
+++ b/common/constitution.ts
@@ -3,54 +3,60 @@ const SONGS_PER_USER_DEFAULT = 5;
 
 // Types
 interface UserConstitution {
-  user: string;
-  joinDate: string;
+    user: string;
+    joinDate: string;
 }
 
 interface SongConstitution {
-  song: number;
-  user: string;
-  addDate: string;
+    id: number;
+    song: number;
+    user: string;
+    addDate: string;
 }
 
 interface Constitution {
-  id: number;
-  name: string;
-  description: string;
-  owner: string;
-  creationDate: string;
-  nSongs: number;
-  userConstitution: UserConstitution[];
-  songConstitution: SongConstitution[];
+    id: number;
+    name: string;
+    description: string;
+    owner: string;
+    creationDate: string;
+    nSongs: number;
+    userConstitution: UserConstitution[];
+    songConstitution: SongConstitution[];
 }
 
 // Requests
 interface CreateConstitutionRequestBody {
-  name: string;
-  description: string;
-  nSongs: number;
+    name: string;
+    description: string;
+    nSongs: number;
 }
 
 interface JoinConstitutionRequestBody {
-  id: number;
+    id: number;
 }
 
 interface LeaveConstitutionRequestBody {
-  id: number;
+    id: number;
 }
 
 interface AddSongConstitutionRequestBody {
-  song: number;
-  constitution: number;
+    song: number;
+    constitution: number;
 }
 
-export { 
-  type Constitution,
-  type UserConstitution,
-  type SongConstitution,
-  type AddSongConstitutionRequestBody,
-  type CreateConstitutionRequestBody,
-  type JoinConstitutionRequestBody,
-  type LeaveConstitutionRequestBody,
-  SONGS_PER_USER_DEFAULT
+interface RemoveSongConstitutionRequestBody {
+    songParticipationId: number
+}
+
+export {
+    type Constitution,
+    type UserConstitution,
+    type SongConstitution,
+    type AddSongConstitutionRequestBody,
+    type RemoveSongConstitutionRequestBody,
+    type CreateConstitutionRequestBody,
+    type JoinConstitutionRequestBody,
+    type LeaveConstitutionRequestBody,
+    SONGS_PER_USER_DEFAULT
 };

--- a/common/websocket.ts
+++ b/common/websocket.ts
@@ -1,53 +1,60 @@
 import type { UserConstitution, SongConstitution } from "./constitution";
 
 enum WebsocketEvents {
-  CST_USER_JOIN = "cst-user-join",        // OUT
-  CST_USER_LEAVE = "cst-user-leave",      // OUT
-  CST_SONG_ADD = "cst-song-add",          // IN
-  CST_SUBSCRIBE = "cst-subscribe",        // IN
-  CST_UNSUBSCRIBE = "cst-unsubscribe"     // IN
+    CST_USER_JOIN = "cst-user-join",        // OUT
+    CST_USER_LEAVE = "cst-user-leave",      // OUT
+    CST_SONG_ADD = "cst-song-add",          // IN
+    CST_SONG_REMOVE = "cst-song-remove",    // IN
+    CST_SUBSCRIBE = "cst-subscribe",        // IN
+    CST_UNSUBSCRIBE = "cst-unsubscribe"     // IN
 }
 
 // IN MESSAGES (client ==> server)
 /// The default interface have the "deltaAuth" field to authenticate the user and validate the request
 interface WSInMessage {
-  deltaAuth: string;
+    deltaAuth: string;
 }
 
 /// Subscribe to real-time changes of a constitution
 interface WSCstSubscribeMessage extends WSInMessage {
-  constitution: number;
+    constitution: number;
 }
 
 /// Unsubscribre to the changes
 interface WSCstUnsubscribeMessage extends WSInMessage {
-  constitution: number;
+    constitution: number;
 }
 
 // OUT MESSAGES (server ==> clients)
 /// Message when a user joins a constitution
 interface WSCstUserJoinMessage {
-  constitution: number;         // ID of the constitution
-  userConstitution: UserConstitution;
+    constitution: number;         // ID of the constitution
+    userConstitution: UserConstitution;
 }
 
 /// Message when a user leaves a constitution with the id of the user and the constitution.
 interface WSCstUserLeaveMessage {
-  constitution: number;
-  user: string;
+    constitution: number;
+    user: string;
 }
 
 interface WSCstSongAddMessage {
-  constitution: number;
-  songConstitution: SongConstitution;
+    constitution: number;
+    songConstitution: SongConstitution;
+}
+
+interface WSCstSongRemoveMessage {
+    constitution: number;
+    songConstitution: SongConstitution;
 }
 
 export {
-  WebsocketEvents,
-  type WSInMessage,
-  type WSCstSongAddMessage,
-  type WSCstUserJoinMessage,
-  type WSCstUserLeaveMessage,
-  type WSCstSubscribeMessage,
-  type WSCstUnsubscribeMessage,
+    WebsocketEvents,
+    type WSInMessage,
+    type WSCstSongAddMessage,
+    type WSCstSongRemoveMessage,
+    type WSCstUserJoinMessage,
+    type WSCstUserLeaveMessage,
+    type WSCstSubscribeMessage,
+    type WSCstUnsubscribeMessage,
 };

--- a/frontend/src/app/components/pages/constitution-page/add-song-form/add-song-form.html
+++ b/frontend/src/app/components/pages/constitution-page/add-song-form/add-song-form.html
@@ -23,7 +23,7 @@
   <div formArrayName="artists">
     <h4>Artists</h4>
     <button (click)="addArtist()">+ Add another artist</button>
-    @for (artistForm of artists.controls; track artistForm; let i = $index) {
+    @for (artistForm of artists.controls; track $index; let i = $index) {
       <div [formGroupName]="i">
         <div class="artist-inputs">
           Artist {{ i + 1 }}

--- a/frontend/src/app/components/pages/constitution-page/constitution-page.html
+++ b/frontend/src/app/components/pages/constitution-page/constitution-page.html
@@ -40,7 +40,7 @@
             </li>
           }
         </ul>
-        @if (observers.user?.id === (currentUser?.id ?? "")) {
+        @if (observers.user?.id === (currentUser?.id ?? '')) {
           <button (click)="removeSong(songConstitution.id)">Remove song</button>
         }
       }

--- a/frontend/src/app/components/pages/constitution-page/constitution-page.html
+++ b/frontend/src/app/components/pages/constitution-page/constitution-page.html
@@ -40,6 +40,9 @@
             </li>
           }
         </ul>
+        @if (observers.user?.id === (currentUser?.id ?? "")) {
+          <button (click)="removeSong(songConstitution.id)">Remove song</button>
+        }
       }
     }
   }

--- a/frontend/src/app/components/pages/constitution-page/constitution-page.ts
+++ b/frontend/src/app/components/pages/constitution-page/constitution-page.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, inject } from '@angular/core';
-import { Constitution, SongConstitution, UserConstitution } from '../../../../../../common/constitution';
+import { Constitution, RemoveSongConstitutionRequestBody, SongConstitution, UserConstitution } from '../../../../../../common/constitution';
 import { Observable, Subscription } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { AddSongForm } from './add-song-form/add-song-form';
@@ -15,6 +15,7 @@ import { Sources } from '../../../services/sources';
 import { Title } from '@angular/platform-browser';
 import { User } from '../../../../../../common/user';
 import { Users } from '../../../services/users';
+import { HttpRequests } from '../../../services/requests/http-requests';
 
 function sortByJoinDate(a: { joinDate: string }, b: { joinDate: string }): number {
   if (a.joinDate === b.joinDate) return 0;
@@ -41,6 +42,7 @@ export class ConstitutionPage implements OnDestroy {
   users = inject(Users);
   songs = inject(Songs);
   sources = inject(Sources);
+  httpRequests = inject(HttpRequests);
 
   private subscriptions: Subscription = new Subscription();
 
@@ -118,5 +120,10 @@ export class ConstitutionPage implements OnDestroy {
     songs.sort((a, b) => sortByAddDate(a, b));
 
     return songs;
+  }
+
+  removeSong(participation: number): void {
+    this.httpRequests.authenticatedPostRequest<RemoveSongConstitutionRequestBody>("constitution/removeSong", { songParticipationId: participation })
+      .catch((err) => console.error(err))
   }
 }

--- a/frontend/src/app/components/pages/constitution-page/constitution-page.ts
+++ b/frontend/src/app/components/pages/constitution-page/constitution-page.ts
@@ -1,5 +1,10 @@
 import { Component, OnDestroy, inject } from '@angular/core';
-import { Constitution, RemoveSongConstitutionRequestBody, SongConstitution, UserConstitution } from '../../../../../../common/constitution';
+import {
+  Constitution,
+  RemoveSongConstitutionRequestBody,
+  SongConstitution,
+  UserConstitution,
+} from '../../../../../../common/constitution';
 import { Observable, Subscription } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { AddSongForm } from './add-song-form/add-song-form';
@@ -8,6 +13,7 @@ import { Artists } from '../../../services/artists';
 import { AsyncPipe } from '@angular/common';
 import { Constitutions } from '../../../services/constitutions';
 import { HttpErrorResponse } from '@angular/common/http';
+import { HttpRequests } from '../../../services/requests/http-requests';
 import { RedirectToUserProfile } from '../../utils/redirect-to-user-profile/redirect-to-user-profile';
 import { Song } from '../../../../../../common/song';
 import { Songs } from '../../../services/songs';
@@ -15,7 +21,6 @@ import { Sources } from '../../../services/sources';
 import { Title } from '@angular/platform-browser';
 import { User } from '../../../../../../common/user';
 import { Users } from '../../../services/users';
-import { HttpRequests } from '../../../services/requests/http-requests';
 
 function sortByJoinDate(a: { joinDate: string }, b: { joinDate: string }): number {
   if (a.joinDate === b.joinDate) return 0;
@@ -123,7 +128,10 @@ export class ConstitutionPage implements OnDestroy {
   }
 
   removeSong(participation: number): void {
-    this.httpRequests.authenticatedPostRequest<RemoveSongConstitutionRequestBody>("constitution/removeSong", { songParticipationId: participation })
-      .catch((err) => console.error(err))
+    this.httpRequests
+      .authenticatedPostRequest<RemoveSongConstitutionRequestBody>('constitution/removeSong', {
+        songParticipationId: participation,
+      })
+      .catch((err) => console.error(err));
   }
 }

--- a/frontend/src/app/services/constitutions.ts
+++ b/frontend/src/app/services/constitutions.ts
@@ -9,6 +9,7 @@ import {
 import { Injectable, OnDestroy, inject } from '@angular/core';
 import {
   WSCstSongAddMessage,
+  WSCstSongRemoveMessage,
   WSCstSubscribeMessage,
   WSCstUnsubscribeMessage,
   WSCstUserJoinMessage,
@@ -42,6 +43,7 @@ export class Constitutions implements OnDestroy {
     // Initialize the list of events to react with websockets
     this.wsEvents = new Map()
       .set(WebsocketEvents.CST_SONG_ADD, this.onSongAdd.bind(this))
+      .set(WebsocketEvents.CST_SONG_REMOVE, this.onSongRemove.bind(this))
       .set(WebsocketEvents.CST_USER_JOIN, this.onUserJoin.bind(this))
       .set(WebsocketEvents.CST_USER_LEAVE, this.onUserLeave.bind(this));
 
@@ -103,6 +105,16 @@ export class Constitutions implements OnDestroy {
     if (!constitution) return;
     constitution.value?.songConstitution.push(message.songConstitution);
     constitution.next(constitution.value);
+  }
+
+  private onSongRemove(message: WSCstSongRemoveMessage): void {
+    const constitution = this.constitutions.get(message.constitution);
+    if (!constitution) return;
+
+    if (constitution.value) {
+      constitution.value.songConstitution = constitution.value.songConstitution.filter((participation) => message.songConstitution.id !== participation.id);
+      constitution.next(constitution.value);
+    }
   }
 
   private onUserJoin(message: WSCstUserJoinMessage): void {

--- a/frontend/src/app/services/constitutions.ts
+++ b/frontend/src/app/services/constitutions.ts
@@ -112,7 +112,9 @@ export class Constitutions implements OnDestroy {
     if (!constitution) return;
 
     if (constitution.value) {
-      constitution.value.songConstitution = constitution.value.songConstitution.filter((participation) => message.songConstitution.id !== participation.id);
+      constitution.value.songConstitution = constitution.value.songConstitution.filter(
+        (participation) => message.songConstitution.id !== participation.id,
+      );
       constitution.next(constitution.value);
     }
   }


### PR DESCRIPTION
# Description
This PR adds the ability for a user to withdraw a song they previously added to a constitution. This currently does not remove the song and its artists from the database.

## :rocket: New feature
- A new backend route at POST `api/constitution/removeSong`
- A new WS event and its related message types
- A new button in the frontend
All in all very exciting stuff.

## :bug: Bugfix
- Fixed a performance warning from angular due to how we where using the `tracking` directive in HTML for loops for the control forms.

## :hammer_and_wrench: Internal
- Bumped the biome's schema version for the backend
- Some unifying of error formatting in the backend