### PR TITLE
Add missing redirect to constitution owner profile (hotfix)

### DIFF
--- a/frontend/src/app/components/pages/constitution-page/constitution-page.html
+++ b/frontend/src/app/components/pages/constitution-page/constitution-page.html
@@ -4,7 +4,7 @@
   <h1>{{ constitution.name }} (id : {{ constitution.id }})</h1>
   <hr />
   <p>Description : {{ constitution.description }}</p>
-  <p>Owner: {{ (users.get(constitution.owner) | async)?.displayName }}</p>
+  <p>Owner: <app-redirect-to-user-profile [user]="users.get(constitution.owner) | async" /> </p>
   <p>Number of songs: {{ constitution.songConstitution.length }} / {{ getMaxNSongs(constitution) }}</p>
   <h3>Participants</h3>
   @for (userConstitution of getUsers(); track $index) {

--- a/frontend/src/app/components/pages/constitution-page/constitution-page.html
+++ b/frontend/src/app/components/pages/constitution-page/constitution-page.html
@@ -4,7 +4,7 @@
   <h1>{{ constitution.name }} (id : {{ constitution.id }})</h1>
   <hr />
   <p>Description : {{ constitution.description }}</p>
-  <p>Owner: <app-redirect-to-user-profile [user]="users.get(constitution.owner) | async" /> </p>
+  <p>Owner: <app-redirect-to-user-profile [user]="users.get(constitution.owner) | async" /></p>
   <p>Number of songs: {{ constitution.songConstitution.length }} / {{ getMaxNSongs(constitution) }}</p>
   <h3>Participants</h3>
   @for (userConstitution of getUsers(); track $index) {

--- a/frontend/src/app/components/pages/user-page/user-page.ts
+++ b/frontend/src/app/components/pages/user-page/user-page.ts
@@ -22,8 +22,6 @@ export class UserPage implements OnDestroy {
   private subscriptions: Subscription = new Subscription();
 
   // Observable of the user data
-  private userObs: Observable<User> | undefined;
-  private userHandle = '';
   user: User | undefined;
   userError: HttpErrorResponse | undefined;
   isCurrentUser = false;
@@ -35,11 +33,9 @@ export class UserPage implements OnDestroy {
   constructor() {
     // Get the user from the route
     this.activatedRoute.params.subscribe((params) => {
-      this.userHandle = params['handle'];
-      this.users.getFromHandle(this.userHandle).then((obs) => {
-        this.userObs = obs;
-
-        const subscription = this.userObs.subscribe({
+      const handle = params['handle'];
+      this.users.getFromHandle(handle).then((obs) => {
+        const subscription = obs.subscribe({
           next: (data) => {
             this.user = data;
             this.titleService.setTitle(this.user.displayName);
@@ -54,7 +50,7 @@ export class UserPage implements OnDestroy {
 
       this.users.getCurrentUser().then((currentUser) => {
         currentUser.subscribe((user) => {
-          this.isCurrentUser = user.handle === this.userHandle;
+          this.isCurrentUser = user.handle === handle;
         });
       });
     });

--- a/frontend/src/app/components/pages/user-page/user-page.ts
+++ b/frontend/src/app/components/pages/user-page/user-page.ts
@@ -1,8 +1,8 @@
 import { Component, OnDestroy, inject } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { CurrentUserForm } from './current-user-form/current-user-form';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Subscription } from 'rxjs';
 import { Title } from '@angular/platform-browser';
 import { User } from '../../../../../../common/user';
 import { Users } from '../../../services/users';


### PR DESCRIPTION
# Description
<!-- Keep only relevant sections -->

## :rocket: New feature
* In a constitution, add a redirect to the owner's profile page.

## :hammer_and_wrench: Internal
* Refactor logic to subscribe to user's change on the `UserPage`.