### PR TITLE
Fix erroneous behavior of form deletion in `add-song-page` (DELTA-96)

### DIFF
--- a/frontend/src/app/components/pages/constitution-page/add-song-form/add-song-form.html
+++ b/frontend/src/app/components/pages/constitution-page/add-song-form/add-song-form.html
@@ -7,7 +7,7 @@
   <div formArrayName="sources">
     <h4>Sources</h4>
     <button (click)="addSource()">+ Add another source</button>
-    @for (sourceForm of sources.controls; track $index; let i = $index) {
+    @for (sourceForm of sources.controls; track sourceForm; let i = $index) {
       <div [formGroupName]="i">
         <div class="artist-inputs">
           Source {{ i + 1 }}
@@ -23,7 +23,7 @@
   <div formArrayName="artists">
     <h4>Artists</h4>
     <button (click)="addArtist()">+ Add another artist</button>
-    @for (artistForm of artists.controls; track $index; let i = $index) {
+    @for (artistForm of artists.controls; track artistForm; let i = $index) {
       <div [formGroupName]="i">
         <div class="artist-inputs">
           Artist {{ i + 1 }}


### PR DESCRIPTION
# Description
We were using an incorrect `tracking` directive in Angular's for loops, causing the wrong views to get dropped when deleting an element from our FormArrays for both sources and artists. 

## :bug: Bugfix
- Angular now correctly tracks the underlying objects instead of their index, making deletion behave as expected